### PR TITLE
Make import specific

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,7 @@ requirements:
 
 test:
   imports:
-    - trame
-    - trame.modules
+    - trame.widgets.markdown
   commands:
     - pip check
   requires:


### PR DESCRIPTION
I'm working on the conda-forge PyPI mapping, and the test imports are used as a form of metadata. Thus it's really helpful if those imports are made specific, like the example here.

Here are the affected Trame feedstocks:

* [ ] trame-markdown
* [ ] trame-vuetify
* [ ] trame-components
* [ ] trame-deckgl
* [ ] trame-plotly
* [ ] trame-matplotlib
* [ ] trame-router
* [ ] trame-vega
* [ ] trame-vtk
* [ ] trame-rca
* [ ] trame-simput
* [ ] trame

I'm deliberately not bumping the build number or rerendering since I don't want to create a new build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
